### PR TITLE
Using latest Mac OS X as the build SDK

### DIFF
--- a/SCDesktopSharingKit/ShareOnSoundCloud.xcodeproj/project.pbxproj
+++ b/SCDesktopSharingKit/ShareOnSoundCloud.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -457,7 +457,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The build SDK was locked to 10.6 on the app & in the JSONKit framework.
I updated both.
